### PR TITLE
Version 0.0.1

### DIFF
--- a/compact.css
+++ b/compact.css
@@ -12,14 +12,14 @@ a {
 
 body {
   font-family: sans-serif;
-  font-size: 8pt;
+  font-size: 7.6pt;
   line-height: 1.15;
   color: #4A4A4A;
 }
 
 /* Section headings */
 h2, h3 {
-  font-size: 8pt;
+  font-size: 7.6pt;
   font-weight: bold;
   color: #000000;
   margin: 6pt 0 4pt;
@@ -94,7 +94,7 @@ body > h1:first-of-type { margin-top: 0; }
 .exp-bullets li { margin-bottom: 3pt; }
 
 .exp-bullets .lead { 
-  color: #1F2937;
+  color: #374151;
   font-weight: bold;
 }
 
@@ -140,9 +140,14 @@ body > h1:first-of-type { margin-top: 0; }
 
 .proj-bullets li { margin-bottom: 3pt; }
 
+.proj-bullets .lead {
+  color: #374151;
+  font-weight: bold;
+}
+
 .proj-link {
   font-weight: normal;
-  font-size: 8pt;
+  font-size: 7.6pt;
   margin-left: 4px;
 }
 

--- a/compact.css
+++ b/compact.css
@@ -263,3 +263,7 @@ body > h1:first-of-type { margin-top: 0; }
 }
 
 .cert-bullets li { margin-bottom: 3pt; }
+
+/* Subtle spacing between Education entries */
+.edu-header { margin-top: 5pt; }
+.edu-header:first-of-type { margin-top: 0; }

--- a/compact.css
+++ b/compact.css
@@ -93,6 +93,11 @@ body > h1:first-of-type { margin-top: 0; }
 
 .exp-bullets li { margin-bottom: 3pt; }
 
+.exp-bullets .lead { 
+  color: #1F2937;
+  font-weight: bold;
+}
+
 /* =========================
    SKILLS
    ========================= */

--- a/compact.css
+++ b/compact.css
@@ -3,12 +3,37 @@
   margin: 0.4in 0.5in 0.4in 0.5in;
 }
 
-/* ---- LINKS ---- */
-a {
+/* Base link style (stay gray) */
+a,
+a:link,
+a:visited,
+a:active {
   color: #4A4A4A;
   text-decoration: none;
 }
-/* ----       ---- */
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Header: hover turns links blue */
+.centered-header .contact-info a:hover {
+  color: #0000EE;
+}
+
+/* Projects: "View Project" link is always blue */
+.proj-link a,
+.proj-link a:link,
+.proj-link a:visited,
+.proj-link a:active {
+  color: #0000EE;
+  text-decoration: none;
+}
+
+.proj-link a:hover {
+  color: #0000EE;
+  text-decoration: underline;
+}
 
 body {
   font-family: sans-serif;

--- a/compact.css
+++ b/compact.css
@@ -37,14 +37,14 @@ a:hover {
 
 body {
   font-family: sans-serif;
-  font-size: 7.6pt;
+  font-size: 7.4pt;
   line-height: 1.15;
   color: #4A4A4A;
 }
 
 /* Section headings */
 h2, h3 {
-  font-size: 7.6pt;
+  font-size: 7.4pt;
   font-weight: bold;
   color: #000000;
   margin: 6pt 0 4pt;
@@ -127,10 +127,31 @@ body > h1:first-of-type { margin-top: 0; }
    SKILLS
    ========================= */
 
-   .skills strong {
-    font-weight: normal;
-    color: inherit;
-   }
+.skills {
+  /* Pull skills closer to the SKILLS heading */
+  margin-top: -8pt;
+}
+
+.skills p {
+  margin-top: 0;
+  margin-bottom: 2pt;
+}
+
+.skills strong {
+  font-weight: normal;
+  color: inherit;
+}
+
+/* Force each skills category label to start on a new line,
+   without adding extra space before the first one */
+.skills strong::before {
+  content: "\A";
+  white-space: pre;
+}
+
+.skills strong:first-of-type::before {
+  content: "";
+}
 
 /* =========================
    PROJECTS
@@ -172,7 +193,7 @@ body > h1:first-of-type { margin-top: 0; }
 
 .proj-link {
   font-weight: normal;
-  font-size: 7.6pt;
+  font-size: 7.4pt;
   margin-left: 4px;
 }
 

--- a/compact.css
+++ b/compact.css
@@ -267,3 +267,15 @@ body > h1:first-of-type { margin-top: 0; }
 /* Subtle spacing between Education entries */
 .edu-header { margin-top: 5pt; }
 .edu-header:first-of-type { margin-top: 0; }
+
+/* Justify all bullet text */
+.exp-bullets li,
+.proj-bullets li,
+.edu-bullets li,
+.cert-bullets li {
+  text-align: justify;
+  -webkit-hyphens: auto;
+      -ms-hyphens: auto;
+          hyphens: auto;
+  overflow-wrap: anywhere; /* keeps long URLs/terms from spilling */
+}

--- a/compact.css
+++ b/compact.css
@@ -5,7 +5,7 @@
 
 /* ---- LINKS ---- */
 a {
-  color: inherit;
+  color: #4A4A4A;
   text-decoration: none;
 }
 /* ----       ---- */
@@ -14,15 +14,14 @@ body {
   font-family: sans-serif;
   font-size: 8pt;
   line-height: 1.15;
-  color: #101;
+  color: #4A4A4A;
 }
 
+/* Section headings */
 h2, h3 {
   font-size: 8pt;
   font-weight: bold;
-  color: #333;
-  border-bottom: 1px solid #ccc;
-  padding-bottom: 2pt;
+  color: #000000;
   margin: 6pt 0 4pt;
 }
 
@@ -36,13 +35,15 @@ p {
 }
 
 /* Top header spacing fix */
-body > h1:first-of-type {
-  margin-top: 0;
+body > h1:first-of-type { margin-top: 0; }
+.centered-header h1 {
+  color: #000000;
+  font-weight: bold;
 }
 
-body > h1:first-of-type {
-  margin-top: 0;
-}
+/* =========================
+   PROFESSIONAL EXPERIENCE
+   ========================= */
 
 .exp-title-line,
 .exp-meta-line {
@@ -50,24 +51,30 @@ body > h1:first-of-type {
   justify-content: space-between;
   margin-top: 4pt;
   margin-bottom: 0pt;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .exp-title {
   text-align: left;
+  color: #4A4A4A;
   flex: 1;
+  font-weight: normal;
 }
 
 .exp-city {
   text-align: right;
   white-space: nowrap;
+  color: #4A4A4A;
   padding-left: 1em;
+  font-weight: normal;
 }
 
 .exp-org {
   text-align: left;
   flex: 1;
+  color: #4A4A4A;
   font-style: normal;
+  font-weight: normal;
 }
 
 .exp-dates {
@@ -75,6 +82,7 @@ body > h1:first-of-type {
   white-space: nowrap;
   font-style: italic;
   padding-left: 1em;
+  font-weight: normal;
 }
 
 .exp-bullets {
@@ -83,9 +91,20 @@ body > h1:first-of-type {
   padding-left: 1.1em;
 }
 
-.exp-bullets li {
-  margin-bottom: 3pt;
-}
+.exp-bullets li { margin-bottom: 3pt; }
+
+/* =========================
+   SKILLS
+   ========================= */
+
+   .skills strong {
+    font-weight: normal;
+    color: inherit;
+   }
+
+/* =========================
+   PROJECTS
+   ========================= */
 
 .proj-header {
   display: flex;
@@ -96,8 +115,8 @@ body > h1:first-of-type {
 
 .proj-title {
   text-align: left;
-  font-weight: bold;
   flex: 1;
+  font-weight: normal;
 }
 
 .proj-date {
@@ -105,7 +124,7 @@ body > h1:first-of-type {
   white-space: nowrap;
   font-style: italic;
   padding-left: 1em;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .proj-bullets {
@@ -114,9 +133,8 @@ body > h1:first-of-type {
   padding-left: 1.1em;
 }
 
-.proj-bullets li {
-  margin-bottom: 3pt;
-}
+.proj-bullets li { margin-bottom: 3pt; }
+
 .proj-link {
   font-weight: normal;
   font-size: 8pt;
@@ -124,25 +142,28 @@ body > h1:first-of-type {
 }
 
 .proj-link a {
-  color: inherit;
+  color: #4A4A4A;
   text-decoration: none;
 }
 
-.proj-link a:hover {
-  text-decoration: underline;
-}
+.proj-link a:hover { text-decoration: underline; }
+
+/* =========================
+   EDUCATION
+   ========================= */
 
 .edu-header {
   display: flex;
   justify-content: space-between;
   margin-top: 1pt;
   margin-bottom: 0pt;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .edu-degree {
   text-align: left;
   flex: 1;
+  font-weight: normal;
 }
 
 .edu-dates {
@@ -150,7 +171,7 @@ body > h1:first-of-type {
   white-space: nowrap;
   font-style: italic;
   padding-left: 1em;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .edu-inst {
@@ -166,12 +187,14 @@ body > h1:first-of-type {
   padding-left: 1.1em;
 }
 
-.edu-bullets li {
-  margin-bottom: 1pt;
-}
+.edu-bullets li { margin-bottom: 1pt; }
+
+/* =========================
+   CERTIFICATIONS
+   ========================= */
 
 .cert-title {
-  font-weight: bold;
+  font-weight: normal;
   margin-top: 6pt;
   margin-bottom: 0pt;
 }
@@ -181,19 +204,21 @@ body > h1:first-of-type {
   justify-content: space-between;
   margin-top: 2pt;
   margin-bottom: 2pt;
+  font-weight: normal;
 }
 
 .cert-org {
   text-align: left;
   flex: 1;
+  font-weight: normal;
 }
 
 .cert-date {
   text-align: right;
   white-space: nowrap;
   font-style: italic;
-  font-weight: bold;
   padding-left: 1em;
+  font-weight: normal;
 }
 
 .cert-bullets {
@@ -202,6 +227,4 @@ body > h1:first-of-type {
   padding-left: 1.1em;
 }
 
-.cert-bullets li {
-  margin-bottom: 3pt;
-}
+.cert-bullets li { margin-bottom: 3pt; }

--- a/data/roles/business_analyst.R
+++ b/data/roles/business_analyst.R
@@ -1,0 +1,65 @@
+role <- list(
+  key = "business_analyst",
+  headline = "Business Analyst",
+  summary = "Business analyst who favors clarity over noise, leaning on clean visuals and language tailored to the audience it serves.
+        I wrangle data, create dashboards, and develop practical forecasts shaped by real questions from the people who use them.",
+  skills_tbl = tibble::tribble(
+    ~area, ~skills,
+    "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), GitHub, Power BI (Power Query, DAX), Tableau, Python, R, TypeScript, EViews, JMP",
+  ),
+  portfolio_url = "https://eagereconomist-ba.carrd.co/",
+  portfolio_label = "Portfolio",
+  show_portfolio_header = TRUE,
+  experience_override = tibble::tribble(
+  ~title, ~unit, ~startMonth, ~startYear, ~endMonth, ~endYear, ~where, ~detail,
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Increased tutoring coverage for economics/business tutors by 20%: after analyzing
+  SQL session logs (course, day/time, duration). Demand tracked by course and peak hours showed concentration in intermediate microeconomics, and the reallocation matched support to when students showed up.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Improved a students grade in econometrics from 45% to 90% in four weeks: working with
+  the course professor and the student. Analyzed item-level quiz/exam data over multiple weeks, tracked per-topic mastery, spotted gaps in core econometrics concepts, and targeted practice closed those gaps.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Used Python to create 2 monthly parameterized reports for the tutoring center: after partnering
+  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked topic mastery, attendance, and tutoring demand. The reports
+  flagged sections trending below expectations and enabled earlier outreach.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Helped achieve faster faculty interventions and optimized weekly support hours: by analyzing
+  performance data for 120+ upper-division students using Excel & R, identifying drivers like repeat errors on core topics and missed assignments that guided targeted tutoring.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Developed & maintained a KPI Dashboard using Tableau: for the economics courses supported,
+  tailored by class and professor. The dashboard tracked grade distributions, completion rates, and submission timelines, giving instructors a single view to spot at-risk students and adjust review and office hours.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Increased on-time assignment completion by 12%: in an intermediate macroeconomics course by
+  flagging a deadline bottleneck using SQL and R. Analyzed gradebook and submission logs, tracked on-time vs. late by week, and recommended moving key deadlines off Friday nights to the instructor.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Logged 1,200 harness tests for QA: (D-SUB, RJ-45, USB), recording length variance and tolerance; recurring failures by SKU were surfaced 
+  early and fixed before final assembly.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Reviewed 30+ work orders with engineers to apply manufacturing tolerances: (length limits and continuity checks) while optimizing harness
+  lengths. Out-of-range cuts were flagged, and re-crimps were reduced on the line.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Tracked progress systematically: to maintain accurate records and support production analysis while following detailed work orders to 
+  assemble harnesses and subassemblies."
+),
+  projects_override = tibble::tribble(
+  ~area, ~link, ~endMonth, ~year, ~detail_1, ~detail_2, ~detail_3,
+  "SAS Churn Rate Dashboard | Databel Retention Analytics", "https://eagereconomist-da.carrd.co/#project-two", "October", 2025,
+  "Used Tableau to flag 34.7% churn among customers: not on an unlimited plan who used less than 5 GB/month; advised marketing to explain the $4.34 in extra charges and migrate them to a better plan.",
+  "Identified 53% churn in customers: outside the internationally active group with twelve months or less in terms of account length. Recommended marketing offer one or two year contracts to stabilize retention.",
+  "Surfaced a high-value, small cohort of 177 customers: on an international plan with zero international calls (average $33.12 monthly charge). Used SQL to export the contact list and recommended outreach run a targeted campaign with a clear explanation of savings.",
+
+  "Light Vehicle Sales Forecasting & Market Analysis | Pinnacle Automotive Analytics Client Engagement", "https://eagereconomist-da.carrd.co/#project-one", "August", 2024,
+  "Developed a 18-month forecast and set a 1.27-1.30 million monthly baseline with ~6% YoY growth rate: through December 2025 using EViews and Excel for inventory planners and sales operations; recommended planning to this
+  baseline and recalibrating only after sustained variance.",
+  "Confirmed a post-1984 shift in seasonality, with sales increasing from November to December: and spring as the strongest merchandising window on average; recommended spring-focused campaigns with a winter KPI monitored against the pre-1984 baseline.",
+  "Found evidence of a link between growth in both real disposable income and YoY light vehicle sales: using EViews & Excel; when income jumped ~30% YoY in March 2021, sales spiked ~112% YoY in April 2021. Advised leadership and 
+  marketing to monitor income growth alongside sales each month to time promotions and inventory ramps",
+
+ "Racquet Segmentation & EDA | Topspin Supply Marketing Initiative", "https://eagereconomist-da.carrd.co/#project-three", "April", 2024,
+  "Verified 70% of models are mid-weight: using polars in Python to filter on specification tables. Recommended to pricing & merchandising to keep advanced lines premium with only small, targeted offers while reserving broader promotions for All-Court and Beginner racquets.",
+  "Priortized the 57% All-Court mix after profiling inventory: with SQL and building visualizations in Tableau. Recommended to merchandizing & E-commerce to feature All-Court first in placement and promotions to move the largest, most flexible stock.",
+  "Directed brand focus to Head: with double Wilson's stock using Power BI to analyze inventory. Advised merchandising to give Head primary promotion slots and homepage visibility before broad discounts."
+  ),
+  show_academic = FALSE,
+  show_github_header = FALSE,
+  max_bullets = 3
+)

--- a/data/roles/crm_analyst.R
+++ b/data/roles/crm_analyst.R
@@ -1,0 +1,65 @@
+role <- list(
+  key = "crm_analyst",
+  headline = "CRM Analyst",
+  summary = "CRM analyst who favors clarity over noise, leaning on clean visuals and language tailored to the audience it serves.
+        I wrangle data, create dashboards, and develop practical forecasts shaped by real questions from the people who use them.",
+  skills_tbl = tibble::tribble(
+    ~area, ~skills,
+    "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), GitHub, Power BI (Power Query, DAX), Tableau, Python, R, TypeScript, EViews, JMP",
+  ),
+  portfolio_url = "https://eagereconomist-da.carrd.co/",
+  portfolio_label = "Portfolio",
+  show_portfolio_header = TRUE,
+  experience_override = tibble::tribble(
+  ~title, ~unit, ~startMonth, ~startYear, ~endMonth, ~endYear, ~where, ~detail,
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Increased tutoring coverage for economics/business tutors by 20%: after analyzing
+  SQL session logs (course, day/time, duration). Demand tracked by course and peak hours showed concentration in intermediate microeconomics, and the reallocation matched support to when students showed up.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Improved a students grade in econometrics from 45% to 90% in four weeks: working with
+  the course professor and the student. Analyzed item-level quiz/exam data over multiple weeks, tracked per-topic mastery, spotted gaps in core econometrics concepts, and targeted practice closed those gaps.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Used Python to create 2 monthly parameterized reports for the tutoring center: after partnering
+  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked topic mastery, attendance, and tutoring demand. The reports
+  flagged sections trending below expectations and enabled earlier outreach.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Helped achieve faster faculty interventions and optimized weekly support hours: by analyzing
+  performance data for 120+ upper-division students using Excel & R, identifying drivers like repeat errors on core topics and missed assignments that guided targeted tutoring.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Developed & maintained a KPI Dashboard using Tableau: for the economics courses supported,
+  tailored by class and professor. The dashboard tracked grade distributions, completion rates, and submission timelines, giving instructors a single view to spot at-risk students and adjust review and office hours.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Increased on-time assignment completion by 12%: in an intermediate macroeconomics course by
+  flagging a deadline bottleneck using SQL and R. Analyzed gradebook and submission logs, tracked on-time vs. late by week, and recommended moving key deadlines off Friday nights to the instructor.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Logged 1,200 harness tests for QA: (D-SUB, RJ-45, USB), recording length variance and tolerance; recurring failures by SKU were surfaced 
+  early and fixed before final assembly.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Reviewed 30+ work orders with engineers to apply manufacturing tolerances: (length limits and continuity checks) while optimizing harness
+  lengths. Out-of-range cuts were flagged, and re-crimps were reduced on the line.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Tracked progress systematically: to maintain accurate records and support production analysis while following detailed work orders to 
+  assemble harnesses and subassemblies."
+),
+  projects_override = tibble::tribble(
+  ~area, ~link, ~endMonth, ~year, ~detail_1, ~detail_2, ~detail_3,
+  "SAS Churn Rate Dashboard | Databel Retention Analytics", "https://eagereconomist-da.carrd.co/#project-two", "October", 2025,
+  "Used Tableau to flag 34.7% churn among customers: not on an unlimited plan who used less than 5 GB/month; advised marketing to explain the $4.34 in extra charges and migrate them to a better plan.",
+  "Identified 53% churn in customers: outside the internationally active group with twelve months or less in terms of account length. Recommended marketing offer one or two year contracts to stabilize retention.",
+  "Surfaced a high-value, small cohort of 177 customers: on an international plan with zero international calls (average $33.12 monthly charge). Used SQL to export the contact list and recommended outreach run a targeted campaign with a clear explanation of savings.",
+
+  "Light Vehicle Sales Forecasting & Market Analysis | Pinnacle Automotive Analytics Client Engagement", "https://eagereconomist-da.carrd.co/#project-one", "August", 2024,
+  "Developed a 18-month forecast and set a 1.27-1.30 million monthly baseline with ~6% YoY growth rate: through December 2025 using EViews and Excel for inventory planners and sales operations; recommended planning to this
+  baseline and recalibrating only after sustained variance.",
+  "Confirmed a post-1984 shift in seasonality, with sales increasing from November to December: and spring as the strongest merchandising window on average; recommended spring-focused campaigns with a winter KPI monitored against the pre-1984 baseline.",
+  "Found evidence of a link between growth in both real disposable income and YoY light vehicle sales: using EViews & Excel; when income jumped ~30% YoY in March 2021, sales spiked ~112% YoY in April 2021. Advised leadership and 
+  marketing to monitor income growth alongside sales each month to time promotions and inventory ramps",
+
+ "Racquet Segmentation & EDA | Topspin Supply Marketing Initiative", "https://eagereconomist-da.carrd.co/#project-three", "April", 2024,
+  "Verified 70% of models are mid-weight: using polars in Python to filter on specification tables. Recommended to pricing & merchandising to keep advanced lines premium with only small, targeted offers while reserving broader promotions for All-Court and Beginner racquets.",
+  "Priortized the 57% All-Court mix after profiling inventory: with SQL and building visualizations in Tableau. Recommended to merchandizing & E-commerce to feature All-Court first in placement and promotions to move the largest, most flexible stock.",
+  "Directed brand focus to Head: with double Wilson's stock using Power BI to analyze inventory. Advised merchandising to give Head primary promotion slots and homepage visibility before broad discounts."
+  ),
+  show_academic = FALSE,
+  show_github_header = FALSE,
+  max_bullets = 3
+)

--- a/data/roles/data_analyst.R
+++ b/data/roles/data_analyst.R
@@ -12,5 +12,6 @@ role <- list(
   experience_override = NULL,
   projects_override = NULL,
   show_academic = FALSE,
+  show_github_header = FALSE,
   max_bullets = 3
 )

--- a/data/roles/data_analyst.R
+++ b/data/roles/data_analyst.R
@@ -2,7 +2,7 @@ role <- list(
   key = "data_analyst",
   headline = "Data Analyst",
   summary = "Data analyst who favors clarity over noise, leaning on clean visuals and language tailored to the audience it serves.
-        I build dashboards and practical forecasts shaped by real questions from the people who use them.",
+        I wrangle data, create dashboards, and develop practical forecasts shaped by real questions from the people who use them.",
   skills_tbl = tibble::tribble(
     ~area, ~skills,
     "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), GitHub, Power BI (Power Query, DAX), Tableau, Python, R, TypeScript, EViews, JMP",
@@ -50,7 +50,7 @@ role <- list(
   "Light Vehicle Sales Forecasting & Market Analysis | Pinnacle Automotive Analytics Client Engagement", "https://eagereconomist-da.carrd.co/#project-one", "August", 2024,
   "Developed a 18-month forecast and set a 1.27-1.30 million monthly baseline with ~6% YoY growth rate: through December 2025 using EViews and Excel for inventory planners and sales operations; recommended planning to this
   baseline and recalibrating only after sustained variance.",
-  "Uncovered that there was a post-1984 November through December increase in light vehicle sales: and spring as the best season for merchandising on average using Excel; recommended leaning into spring campaigns and tracking a winter seasonality KPI against the pre-1984 pattern.",
+  "Confirmed a post-1984 shift in seasonality, with sales increasing from November to December: and spring as the strongest merchandising window on average; recommended spring-focused campaigns with a winter KPI monitored against the pre-1984 baseline.",
   "Found evidence of a link between growth in both real disposable income and YoY light-vehicle sales: using EViews & Excel; when income jumped ~30% YoY in March 2021, sales spiked ~112% YoY in April 2021. Advised leadership and 
   marketing to monitor income growth alongside sales each month to time promotions and inventory ramps",
 

--- a/data/roles/data_analyst.R
+++ b/data/roles/data_analyst.R
@@ -19,7 +19,7 @@ role <- list(
   the course professor and the student. Analyzed item-level quiz/exam data over multiple weeks, tracked per-topic mastery, spotted gaps in core econometrics concepts, and targeted practice closed those gaps.",
   
   "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Used Python to create 2 monthly parameterized reports for the tutoring center: after partnering
-  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked per-course accuracy, topic mastery, attendance, and tutoring demand. They
+  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked per-course accuracy, topic mastery, attendance, and tutoring demand. The reports
   flagged sections trending below expectations and enabled earlier outreach.",
   
   "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Helped achieve faster faculty interventions and optimized weekly support hours: by analyzing
@@ -38,7 +38,7 @@ role <- list(
   lengths. Out-of-range cuts were flagged, and re-crimps were reduced on the line.",
   
   "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Tracked progress systematically: to maintain accurate records and support production analysis while following detailed work orders to 
-  assemble harnesses and subassemblies"
+  assemble harnesses and subassemblies."
 ),
   projects_override = tibble::tribble(
   ~area, ~link, ~endMonth, ~year, ~detail_1, ~detail_2, ~detail_3,
@@ -51,7 +51,7 @@ role <- list(
   "Developed a 18-month forecast and set a 1.27-1.30 million monthly baseline with ~6% YoY growth rate: through December 2025 using EViews and Excel for inventory planners and sales operations; recommended planning to this
   baseline and recalibrating only after sustained variance.",
   "Confirmed a post-1984 shift in seasonality, with sales increasing from November to December: and spring as the strongest merchandising window on average; recommended spring-focused campaigns with a winter KPI monitored against the pre-1984 baseline.",
-  "Found evidence of a link between growth in both real disposable income and YoY light-vehicle sales: using EViews & Excel; when income jumped ~30% YoY in March 2021, sales spiked ~112% YoY in April 2021. Advised leadership and 
+  "Found evidence of a link between growth in both real disposable income and YoY light vehicle sales: using EViews & Excel; when income jumped ~30% YoY in March 2021, sales spiked ~112% YoY in April 2021. Advised leadership and 
   marketing to monitor income growth alongside sales each month to time promotions and inventory ramps",
 
  "Racquet Segmentation & EDA | Topspin Supply Marketing Initiative", "https://eagereconomist-da.carrd.co/#project-three", "April", 2024,

--- a/data/roles/data_analyst.R
+++ b/data/roles/data_analyst.R
@@ -1,7 +1,8 @@
 role <- list(
   key = "data_analyst",
   headline = "Data Analyst",
-  summary = "test",
+  summary = "Data analyst who favors clarity over noise, leaning on clean visuals and language tailored to the audience it serves.
+        I build dashboards and practical forecasts shaped by real questions from the people who use them.",
   skills_tbl = tibble::tribble(
     ~area, ~skills,
     "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), GitHub, Power BI (Power Query, DAX, Data Modeling), Tableau, Python, R, EViews, JMP",

--- a/data/roles/data_analyst.R
+++ b/data/roles/data_analyst.R
@@ -4,7 +4,7 @@ role_data <- list(
     ~area, ~skills,
     "Programming", "Python, SQL, R / RStudio, EViews, JMP",
     "Analytics & ML", "EDA, Feature Engineering, Model Tuning, Forecasting",
-    "Data Visualization", "Excel, Tableau, ggplot2, Matplotlib, Seaborn, Plotly",
+    "Data Visualization", "Tableau, ggplot2, Matplotlib, Seaborn, Plotly",
     "Data Ops", "Git, GitHub, Docker, Reproducibility (uv, venv, renv), CLI",
     "Tools & Markup Languages", "Excel, Word, Powerpoint, RMarkdown"
   ),

--- a/data/roles/data_analyst.R
+++ b/data/roles/data_analyst.R
@@ -19,7 +19,7 @@ role <- list(
   the course professor and the student. Analyzed item-level quiz/exam data over multiple weeks, tracked per-topic mastery, spotted gaps in core econometrics concepts, and targeted practice closed those gaps.",
   
   "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Used Python to create 2 monthly parameterized reports for the tutoring center: after partnering
-  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked per-course accuracy, topic mastery, attendance, and tutoring demand. The reports
+  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked topic mastery, attendance, and tutoring demand. The reports
   flagged sections trending below expectations and enabled earlier outreach.",
   
   "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Helped achieve faster faculty interventions and optimized weekly support hours: by analyzing

--- a/data/roles/data_analyst.R
+++ b/data/roles/data_analyst.R
@@ -5,11 +5,60 @@ role <- list(
         I build dashboards and practical forecasts shaped by real questions from the people who use them.",
   skills_tbl = tibble::tribble(
     ~area, ~skills,
-    "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), GitHub, Power BI (Power Query, DAX, Data Modeling), Tableau, Python, R, EViews, JMP",
-    "Techniques", "Forecasting, KPI Dashboards"
+    "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), GitHub, Power BI (Power Query, DAX), Tableau, Python, R, TypeScript, EViews, JMP",
   ),
-  experience_override = NULL,
-  projects_override = NULL,
+  portfolio_url = "https://eagereconomist-da.carrd.co/",
+  portfolio_label = "Portfolio",
+  show_portfolio_header = TRUE,
+  experience_override = tibble::tribble(
+  ~title, ~unit, ~startMonth, ~startYear, ~endMonth, ~endYear, ~where, ~detail,
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Increased tutoring coverage for economics/business tutors by 20%: after analyzing
+  SQL session logs (course, day/time, duration). Demand tracked by course and peak hours showed concentration in intermediate microeconomics, and the reallocation matched support to when students showed up.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Improved a students grade in econometrics from 45% to 90% in four weeks: working with
+  the course professor and the student. Analyzed item-level quiz/exam data over multiple weeks, tracked per-topic mastery, spotted gaps in core econometrics concepts, and targeted practice closed those gaps.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Used Python to create 2 monthly parameterized reports for the tutoring center: after partnering
+  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked per-course accuracy, topic mastery, attendance, and tutoring demand. They
+  flagged sections trending below expectations and enabled earlier outreach.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Helped achieve faster faculty interventions and optimized weekly support hours: by analyzing
+  performance data for 120+ upper-division students using Excel & R, identifying drivers like repeat errors on core topics and missed assignments that guided targeted tutoring.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Developed & maintained a KPI Dashboard using Tableau: for the economics courses supported,
+  tailored by class and professor. The dashboard tracked grade distributions, completion rates, and submission timelines, giving instructors a single view to spot at-risk students and adjust review and office hours.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Increased on-time assignment completion by 12%: in an intermediate macroeconomics course by
+  flagging a deadline bottleneck using SQL and R. Analyzed gradebook and submission logs, tracked on-time vs. late by week, and recommended moving key deadlines off Friday nights to the instructor.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Logged 1,200 harness tests for QA: (D-SUB, RJ-45, USB), recording length variance and tolerance; recurring failures by SKU were surfaced 
+  early and fixed before final assembly.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Reviewed 30+ work orders with engineers to apply manufacturing tolerances: (length limits and continuity checks) while optimizing harness
+  lengths. Out-of-range cuts were flagged, and re-crimps were reduced on the line.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Tracked progress systematically: to maintain accurate records and support production analysis while following detailed work orders to 
+  assemble harnesses and subassemblies"
+),
+  projects_override = tibble::tribble(
+  ~area, ~link, ~endMonth, ~year, ~detail_1, ~detail_2, ~detail_3,
+  "SAS Churn Rate Dashboard | Databel Retention Analytics", "https://eagereconomist-da.carrd.co/#project-two", "October", 2025,
+  "Used Tableau to flag 34.7% churn among customers: not on an unlimited plan who used less than 5 GB/month; advised marketing to explain the $4.34 in extra charges and migrate them to a better plan.",
+  "Identified 53% churn in customers: outside the internationally active group with twelve months or less in terms of account length. Recommended marketing offer one or two year contracts to stabilize retention.",
+  "Surfaced a high-value, small cohort of 177 customers: on an international plan with zero international calls (average $33.12 monthly charge). Used SQL to export the contact list and recommended outreach run a targeted campaign with a clear explanation of savings.",
+
+  "Light Vehicle Sales Forecasting & Market Analysis | Pinnacle Automotive Analytics Client Engagement", "https://eagereconomist-da.carrd.co/#project-one", "August", 2024,
+  "Developed a 18-month forecast and set a 1.27-1.30 million monthly baseline with ~6% YoY growth rate: through December 2025 using EViews and Excel for inventory planners and sales operations; recommended planning to this
+  baseline and recalibrating only after sustained variance.",
+  "Uncovered that there was a post-1984 November through December increase in light vehicle sales: and spring as the best season for merchandising on average using Excel; recommended leaning into spring campaigns and tracking a winter seasonality KPI against the pre-1984 pattern.",
+  "Found evidence of a link between growth in both real disposable income and YoY light-vehicle sales: using EViews & Excel; when income jumped ~30% YoY in March 2021, sales spiked ~112% YoY in April 2021. Advised leadership and 
+  marketing to monitor income growth alongside sales each month to time promotions and inventory ramps",
+
+ "Racquet Segmentation & EDA | Topspin Supply Marketing Initiative", "https://eagereconomist-da.carrd.co/#project-three", "April", 2024,
+  "Verified 70% of models are mid-weight: using polars in Python to filter on specification tables. Recommended to pricing & merchandising to keep advanced lines premium with only small, targeted offers while reserving broader promotions for All-Court and Beginner racquets.",
+  "Priortized the 57% All-Court mix after profiling inventory: with SQL and building visualizations in Tableau. Recommended to merchandizing & E-commerce to feature All-Court first in placement and promotions to move the largest, most flexible stock.",
+  "Directed brand focus to Head: with double Wilson's stock using Power BI to analyze inventory. Advised merchandising to give Head primary promotion slots and homepage visibility before broad discounts."
+  ),
   show_academic = FALSE,
   show_github_header = FALSE,
   max_bullets = 3

--- a/data/roles/data_analyst.R
+++ b/data/roles/data_analyst.R
@@ -1,6 +1,7 @@
 role <- list(
   key = "data_analyst",
   headline = "Data Analyst",
+  summary = "test",
   skills_tbl = tibble::tribble(
     ~area, ~skills,
     "Programming", "Python, SQL, R/RStudio, EViews, JMP",

--- a/data/roles/data_analyst.R
+++ b/data/roles/data_analyst.R
@@ -1,11 +1,12 @@
-role_data <- list(
+role <- list(
+  key = "data_analyst",
   headline = "Data Analyst",
   skills_tbl = tibble::tribble(
     ~area, ~skills,
-    "Programming", "Python, SQL, R / RStudio, EViews, JMP",
+    "Programming", "Python, SQL, R/RStudio, EViews, JMP",
     "Analytics & ML", "EDA, Feature Engineering, Model Tuning, Forecasting",
     "Data Visualization", "Tableau, ggplot2, Matplotlib, Seaborn, Plotly",
-    "Data Ops", "Git, GitHub, Docker, Reproducibility (uv, venv, renv), CLI",
+    "Data Ops", "Bash, Git, GitHub, Docker, Reproducibility (uv, venv, renv), CLI",
     "Tools & Markup Languages", "Excel, Word, Powerpoint, RMarkdown"
   ),
   experience_override = NULL,

--- a/data/roles/data_analyst.R
+++ b/data/roles/data_analyst.R
@@ -4,11 +4,8 @@ role <- list(
   summary = "test",
   skills_tbl = tibble::tribble(
     ~area, ~skills,
-    "Programming", "Python, SQL, R/RStudio, EViews, JMP",
-    "Analytics & ML", "EDA, Feature Engineering, Model Tuning, Forecasting",
-    "Data Visualization", "Tableau, ggplot2, Matplotlib, Seaborn, Plotly",
-    "Data Ops", "Bash, Git, GitHub, Docker, Reproducibility (uv, venv, renv), CLI",
-    "Tools & Markup Languages", "Excel, Word, Powerpoint, RMarkdown"
+    "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), GitHub, Power BI (Power Query, DAX, Data Modeling), Tableau, Python, R, EViews, JMP",
+    "Techniques", "Forecasting, KPI Dashboards"
   ),
   experience_override = NULL,
   projects_override = NULL,

--- a/data/roles/data_scientist.R
+++ b/data/roles/data_scientist.R
@@ -1,6 +1,7 @@
 role <- list(
     key = "data_scientist",
     headline = "Data Scientist",
+    summary = "test",
     skills_tbl = tibble::tribble(
       ~area, ~skills,
       "Languages & Libraries", "Python (pandas, NumPy, scikit-learn, PyTorch), R (tidyverse, recipes), SQL)",

--- a/data/roles/data_scientist.R
+++ b/data/roles/data_scientist.R
@@ -1,0 +1,15 @@
+role <- list(
+    key = "data_scientist",
+    headline = "Data Scientist",
+    skills_tbl = tibble::tribble(
+      ~area, ~skills,
+      "Languages & Libraries", "Python (pandas, NumPy, scikit-learn, PyTorch), R (tidyverse, recipes), SQL)",
+      "Statistical Modeling", "Time-Series Forecasting (ARIMA, VAR), Structural Models, Causal Inference, Clustering, Dimensionality Reduction, Model Diagnostics",
+      "Visualization & Reporting", "Tableau, ggplot2, Matplotlib, Seaborn, Plotly, RMarkdown",
+      "Dev & Workflow", "Bash, Git, GitHub, Docker, CLI Tools, renv/venv/uv"
+    ),
+    experience_override = NULL,
+    projects_override = NULL,
+    show_academic = FALSE,
+    max_bullets = 3
+)

--- a/data/roles/data_scientist.R
+++ b/data/roles/data_scientist.R
@@ -11,5 +11,6 @@ role <- list(
     experience_override = NULL,
     projects_override = NULL,
     show_academic = FALSE,
+    show_github_header = TRUE,
     max_bullets = 3
 )

--- a/data/roles/forecasting_analyst.R
+++ b/data/roles/forecasting_analyst.R
@@ -1,0 +1,65 @@
+role <- list(
+  key = "forecasting_analyst",
+  headline = "Forecasting Analyst",
+  summary = "Forecasting analyst who favors clarity over noise, leaning on clean visuals and language tailored to the audience it serves.
+        I wrangle data, create dashboards, and develop practical forecasts shaped by real questions from the people who use them.",
+  skills_tbl = tibble::tribble(
+    ~area, ~skills,
+    "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), GitHub, Power BI (Power Query, DAX), Tableau, Python, R, TypeScript, EViews, JMP",
+  ),
+  portfolio_url = "https://eagereconomist-da.carrd.co/",
+  portfolio_label = "Portfolio",
+  show_portfolio_header = TRUE,
+  experience_override = tibble::tribble(
+  ~title, ~unit, ~startMonth, ~startYear, ~endMonth, ~endYear, ~where, ~detail,
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Increased tutoring coverage for economics/business tutors by 20%: after analyzing
+  SQL session logs (course, day/time, duration). Demand tracked by course and peak hours showed concentration in intermediate microeconomics, and the reallocation matched support to when students showed up.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Improved a students grade in econometrics from 45% to 90% in four weeks: working with
+  the course professor and the student. Analyzed item-level quiz/exam data over multiple weeks, tracked per-topic mastery, spotted gaps in core econometrics concepts, and targeted practice closed those gaps.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Used Python to create 2 monthly parameterized reports for the tutoring center: after partnering
+  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked topic mastery, attendance, and tutoring demand. The reports
+  flagged sections trending below expectations and enabled earlier outreach.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Helped achieve faster faculty interventions and optimized weekly support hours: by analyzing
+  performance data for 120+ upper-division students using Excel & R, identifying drivers like repeat errors on core topics and missed assignments that guided targeted tutoring.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Developed & maintained a KPI Dashboard using Tableau: for the economics courses supported,
+  tailored by class and professor. The dashboard tracked grade distributions, completion rates, and submission timelines, giving instructors a single view to spot at-risk students and adjust review and office hours.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Increased on-time assignment completion by 12%: in an intermediate macroeconomics course by
+  flagging a deadline bottleneck using SQL and R. Analyzed gradebook and submission logs, tracked on-time vs. late by week, and recommended moving key deadlines off Friday nights to the instructor.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Logged 1,200 harness tests for QA: (D-SUB, RJ-45, USB), recording length variance and tolerance; recurring failures by SKU were surfaced 
+  early and fixed before final assembly.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Reviewed 30+ work orders with engineers to apply manufacturing tolerances: (length limits and continuity checks) while optimizing harness
+  lengths. Out-of-range cuts were flagged, and re-crimps were reduced on the line.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Tracked progress systematically: to maintain accurate records and support production analysis while following detailed work orders to 
+  assemble harnesses and subassemblies."
+),
+  projects_override = tibble::tribble(
+  ~area, ~link, ~endMonth, ~year, ~detail_1, ~detail_2, ~detail_3,
+  "SAS Churn Rate Dashboard | Databel Retention Analytics", "https://eagereconomist-da.carrd.co/#project-two", "October", 2025,
+  "Used Tableau to flag 34.7% churn among customers: not on an unlimited plan who used less than 5 GB/month; advised marketing to explain the $4.34 in extra charges and migrate them to a better plan.",
+  "Identified 53% churn in customers: outside the internationally active group with twelve months or less in terms of account length. Recommended marketing offer one or two year contracts to stabilize retention.",
+  "Surfaced a high-value, small cohort of 177 customers: on an international plan with zero international calls (average $33.12 monthly charge). Used SQL to export the contact list and recommended outreach run a targeted campaign with a clear explanation of savings.",
+
+  "Light Vehicle Sales Forecasting & Market Analysis | Pinnacle Automotive Analytics Client Engagement", "https://eagereconomist-da.carrd.co/#project-one", "August", 2024,
+  "Developed a 18-month forecast and set a 1.27-1.30 million monthly baseline with ~6% YoY growth rate: through December 2025 using EViews and Excel for inventory planners and sales operations; recommended planning to this
+  baseline and recalibrating only after sustained variance.",
+  "Confirmed a post-1984 shift in seasonality, with sales increasing from November to December: and spring as the strongest merchandising window on average; recommended spring-focused campaigns with a winter KPI monitored against the pre-1984 baseline.",
+  "Found evidence of a link between growth in both real disposable income and YoY light vehicle sales: using EViews & Excel; when income jumped ~30% YoY in March 2021, sales spiked ~112% YoY in April 2021. Advised leadership and 
+  marketing to monitor income growth alongside sales each month to time promotions and inventory ramps",
+
+ "Racquet Segmentation & EDA | Topspin Supply Marketing Initiative", "https://eagereconomist-da.carrd.co/#project-three", "April", 2024,
+  "Verified 70% of models are mid-weight: using polars in Python to filter on specification tables. Recommended to pricing & merchandising to keep advanced lines premium with only small, targeted offers while reserving broader promotions for All-Court and Beginner racquets.",
+  "Priortized the 57% All-Court mix after profiling inventory: with SQL and building visualizations in Tableau. Recommended to merchandizing & E-commerce to feature All-Court first in placement and promotions to move the largest, most flexible stock.",
+  "Directed brand focus to Head: with double Wilson's stock using Power BI to analyze inventory. Advised merchandising to give Head primary promotion slots and homepage visibility before broad discounts."
+  ),
+  show_academic = FALSE,
+  show_github_header = FALSE,
+  max_bullets = 3
+)

--- a/data/roles/junior_data_scientist.R
+++ b/data/roles/junior_data_scientist.R
@@ -1,0 +1,67 @@
+role <- list(
+  key = "junior_data_scientist",
+  headline = "Junior Data Scientist",
+  summary = "Junior data scientist who favors clarity over noise, leaning on clean visuals and language tailored to the audience it serves.
+        I wrangle data, create dashboards, and develop practical forecasts shaped by real questions from the people who use them.",
+  skills_tbl = tibble::tribble(
+    ~area, ~skills,
+    "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), Power BI (Power Query, DAX), Tableau, Python, R, TypeScript, EViews, JMP",
+    "Statistical Modeling", "Time-Series Forecasting (Structural Models, ARIMA, VAR), Causal Inference, Clustering, Dimensionality Reduction, Model Diagnostics",
+    "Dev & Workflow", "Bash, Git, GitHub, Docker, CLI Tools, renv/venv/uv"
+  ),
+  portfolio_url = "https://eagereconomist-da.carrd.co/",
+  portfolio_label = "Portfolio",
+  show_portfolio_header = TRUE,
+  experience_override = tibble::tribble(
+  ~title, ~unit, ~startMonth, ~startYear, ~endMonth, ~endYear, ~where, ~detail,
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Increased tutoring coverage for economics/business tutors by 20%: after analyzing
+  SQL session logs (course, day/time, duration). Demand tracked by course and peak hours showed concentration in intermediate microeconomics, and the reallocation matched support to when students showed up.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Improved a students grade in econometrics from 45% to 90% in four weeks: working with
+  the course professor and the student. Analyzed item-level quiz/exam data over multiple weeks, tracked per-topic mastery, spotted gaps in core econometrics concepts, and targeted practice closed those gaps.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Used Python to create 2 monthly parameterized reports for the tutoring center: after partnering
+  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked topic mastery, attendance, and tutoring demand. The reports
+  flagged sections trending below expectations and enabled earlier outreach.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Helped achieve faster faculty interventions and optimized weekly support hours: by analyzing
+  performance data for 120+ upper-division students using Excel & R, identifying drivers like repeat errors on core topics and missed assignments that guided targeted tutoring.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Developed & maintained a KPI Dashboard using Tableau: for the economics courses supported,
+  tailored by class and professor. The dashboard tracked grade distributions, completion rates, and submission timelines, giving instructors a single view to spot at-risk students and adjust review and office hours.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Increased on-time assignment completion by 12%: in an intermediate macroeconomics course by
+  flagging a deadline bottleneck using SQL and R. Analyzed gradebook and submission logs, tracked on-time vs. late by week, and recommended moving key deadlines off Friday nights to the instructor.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Logged 1,200 harness tests for QA: (D-SUB, RJ-45, USB), recording length variance and tolerance; recurring failures by SKU were surfaced 
+  early and fixed before final assembly.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Reviewed 30+ work orders with engineers to apply manufacturing tolerances: (length limits and continuity checks) while optimizing harness
+  lengths. Out-of-range cuts were flagged, and re-crimps were reduced on the line.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Tracked progress systematically: to maintain accurate records and support production analysis while following detailed work orders to 
+  assemble harnesses and subassemblies."
+),
+  projects_override = tibble::tribble(
+  ~area, ~link, ~endMonth, ~year, ~detail_1, ~detail_2, ~detail_3,
+  "SAS Churn Rate Dashboard | Databel Retention Analytics", "https://eagereconomist-da.carrd.co/#project-two", "October", 2025,
+  "Used Tableau to flag 34.7% churn among customers: not on an unlimited plan who used less than 5 GB/month; advised marketing to explain the $4.34 in extra charges and migrate them to a better plan.",
+  "Identified 53% churn in customers: outside the internationally active group with twelve months or less in terms of account length. Recommended marketing offer one or two year contracts to stabilize retention.",
+  "Surfaced a high-value, small cohort of 177 customers: on an international plan with zero international calls (average $33.12 monthly charge). Used SQL to export the contact list and recommended outreach run a targeted campaign with a clear explanation of savings.",
+
+  "Light Vehicle Sales Forecasting & Market Analysis | Pinnacle Automotive Analytics Client Engagement", "https://eagereconomist-da.carrd.co/#project-one", "August", 2024,
+  "Developed a 18-month forecast and set a 1.27-1.30 million monthly baseline with ~6% YoY growth rate: through December 2025 using EViews and Excel for inventory planners and sales operations; recommended planning to this
+  baseline and recalibrating only after sustained variance.",
+  "Confirmed a post-1984 shift in seasonality, with sales increasing from November to December: and spring as the strongest merchandising window on average; recommended spring-focused campaigns with a winter KPI monitored against the pre-1984 baseline.",
+  "Found evidence of a link between growth in both real disposable income and YoY light vehicle sales: using EViews & Excel; when income jumped ~30% YoY in March 2021, sales spiked ~112% YoY in April 2021. Advised leadership and 
+  marketing to monitor income growth alongside sales each month to time promotions and inventory ramps",
+
+ "Racquet Segmentation & EDA | Topspin Supply Marketing Initiative", "https://eagereconomist-da.carrd.co/#project-three", "April", 2024,
+  "Verified 70% of models are mid-weight: using polars in Python to filter on specification tables. Recommended to pricing & merchandising to keep advanced lines premium with only small, targeted offers while reserving broader promotions for All-Court and Beginner racquets.",
+  "Priortized the 57% All-Court mix after profiling inventory: with SQL and building visualizations in Tableau. Recommended to merchandizing & E-commerce to feature All-Court first in placement and promotions to move the largest, most flexible stock.",
+  "Directed brand focus to Head: with double Wilson's stock using Power BI to analyze inventory. Advised merchandising to give Head primary promotion slots and homepage visibility before broad discounts."
+  ),
+  show_academic = FALSE,
+  show_github_header = TRUE,
+  max_bullets = 3
+)

--- a/data/roles/research_analyst.R
+++ b/data/roles/research_analyst.R
@@ -1,0 +1,65 @@
+role <- list(
+  key = "research_analyst",
+  headline = "Research Analyst",
+  summary = "Research analyst who favors clarity over noise, leaning on clean visuals and language tailored to the audience it serves.
+        I wrangle data, create dashboards, and develop practical forecasts shaped by real questions from the people who use them.",
+  skills_tbl = tibble::tribble(
+    ~area, ~skills,
+    "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), GitHub, Power BI (Power Query, DAX), Tableau, Python, R, TypeScript, EViews, JMP",
+  ),
+  portfolio_url = "https://eagereconomist-da.carrd.co/",
+  portfolio_label = "Portfolio",
+  show_portfolio_header = TRUE,
+  experience_override = tibble::tribble(
+  ~title, ~unit, ~startMonth, ~startYear, ~endMonth, ~endYear, ~where, ~detail,
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Increased tutoring coverage for economics/business tutors by 20%: after analyzing
+  SQL session logs (course, day/time, duration). Demand tracked by course and peak hours showed concentration in intermediate microeconomics, and the reallocation matched support to when students showed up.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Improved a students grade in econometrics from 45% to 90% in four weeks: working with
+  the course professor and the student. Analyzed item-level quiz/exam data over multiple weeks, tracked per-topic mastery, spotted gaps in core econometrics concepts, and targeted practice closed those gaps.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Used Python to create 2 monthly parameterized reports for the tutoring center: after partnering
+  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked topic mastery, attendance, and tutoring demand. The reports
+  flagged sections trending below expectations and enabled earlier outreach.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Helped achieve faster faculty interventions and optimized weekly support hours: by analyzing
+  performance data for 120+ upper-division students using Excel & R, identifying drivers like repeat errors on core topics and missed assignments that guided targeted tutoring.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Developed & maintained a KPI Dashboard using Tableau: for the economics courses supported,
+  tailored by class and professor. The dashboard tracked grade distributions, completion rates, and submission timelines, giving instructors a single view to spot at-risk students and adjust review and office hours.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Increased on-time assignment completion by 12%: in an intermediate macroeconomics course by
+  flagging a deadline bottleneck using SQL and R. Analyzed gradebook and submission logs, tracked on-time vs. late by week, and recommended moving key deadlines off Friday nights to the instructor.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Logged 1,200 harness tests for QA: (D-SUB, RJ-45, USB), recording length variance and tolerance; recurring failures by SKU were surfaced 
+  early and fixed before final assembly.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Reviewed 30+ work orders with engineers to apply manufacturing tolerances: (length limits and continuity checks) while optimizing harness
+  lengths. Out-of-range cuts were flagged, and re-crimps were reduced on the line.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Tracked progress systematically: to maintain accurate records and support production analysis while following detailed work orders to 
+  assemble harnesses and subassemblies."
+),
+  projects_override = tibble::tribble(
+  ~area, ~link, ~endMonth, ~year, ~detail_1, ~detail_2, ~detail_3,
+  "SAS Churn Rate Dashboard | Databel Retention Analytics", "https://eagereconomist-da.carrd.co/#project-two", "October", 2025,
+  "Used Tableau to flag 34.7% churn among customers: not on an unlimited plan who used less than 5 GB/month; advised marketing to explain the $4.34 in extra charges and migrate them to a better plan.",
+  "Identified 53% churn in customers: outside the internationally active group with twelve months or less in terms of account length. Recommended marketing offer one or two year contracts to stabilize retention.",
+  "Surfaced a high-value, small cohort of 177 customers: on an international plan with zero international calls (average $33.12 monthly charge). Used SQL to export the contact list and recommended outreach run a targeted campaign with a clear explanation of savings.",
+
+  "Light Vehicle Sales Forecasting & Market Analysis | Pinnacle Automotive Analytics Client Engagement", "https://eagereconomist-da.carrd.co/#project-one", "August", 2024,
+  "Developed a 18-month forecast and set a 1.27-1.30 million monthly baseline with ~6% YoY growth rate: through December 2025 using EViews and Excel for inventory planners and sales operations; recommended planning to this
+  baseline and recalibrating only after sustained variance.",
+  "Confirmed a post-1984 shift in seasonality, with sales increasing from November to December: and spring as the strongest merchandising window on average; recommended spring-focused campaigns with a winter KPI monitored against the pre-1984 baseline.",
+  "Found evidence of a link between growth in both real disposable income and YoY light vehicle sales: using EViews & Excel; when income jumped ~30% YoY in March 2021, sales spiked ~112% YoY in April 2021. Advised leadership and 
+  marketing to monitor income growth alongside sales each month to time promotions and inventory ramps",
+
+ "Racquet Segmentation & EDA | Topspin Supply Marketing Initiative", "https://eagereconomist-da.carrd.co/#project-three", "April", 2024,
+  "Verified 70% of models are mid-weight: using polars in Python to filter on specification tables. Recommended to pricing & merchandising to keep advanced lines premium with only small, targeted offers while reserving broader promotions for All-Court and Beginner racquets.",
+  "Priortized the 57% All-Court mix after profiling inventory: with SQL and building visualizations in Tableau. Recommended to merchandizing & E-commerce to feature All-Court first in placement and promotions to move the largest, most flexible stock.",
+  "Directed brand focus to Head: with double Wilson's stock using Power BI to analyze inventory. Advised merchandising to give Head primary promotion slots and homepage visibility before broad discounts."
+  ),
+  show_academic = FALSE,
+  show_github_header = FALSE,
+  max_bullets = 3
+)

--- a/data/roles/user_acquisition_analyst.R
+++ b/data/roles/user_acquisition_analyst.R
@@ -1,0 +1,65 @@
+role <- list(
+  key = "user_acquisition_analyst",
+  headline = "User Acquisition Analyst",
+  summary = "User acquisition analyst who favors clarity over noise, leaning on clean visuals and language tailored to the audience it serves.
+        I wrangle data, create dashboards, and develop practical forecasts shaped by real questions from the people who use them.",
+  skills_tbl = tibble::tribble(
+    ~area, ~skills,
+    "Technical Capabilities", "Excel, SQL (BigQuery, PostGreSQL), GitHub, Power BI (Power Query, DAX), Tableau, Python, R, TypeScript, EViews, JMP",
+  ),
+  portfolio_url = "https://eagereconomist-da.carrd.co/",
+  portfolio_label = "Portfolio",
+  show_portfolio_header = TRUE,
+  experience_override = tibble::tribble(
+  ~title, ~unit, ~startMonth, ~startYear, ~endMonth, ~endYear, ~where, ~detail,
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Increased tutoring coverage for economics/business tutors by 20%: after analyzing
+  SQL session logs (course, day/time, duration). Demand tracked by course and peak hours showed concentration in intermediate microeconomics, and the reallocation matched support to when students showed up.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Improved a students grade in econometrics from 45% to 90% in four weeks: working with
+  the course professor and the student. Analyzed item-level quiz/exam data over multiple weeks, tracked per-topic mastery, spotted gaps in core econometrics concepts, and targeted practice closed those gaps.",
+  
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Used Python to create 2 monthly parameterized reports for the tutoring center: after partnering
+  with instructors and administration. Built from SQL session logs and assessment data across all business and economics sections, the reports tracked topic mastery, attendance, and tutoring demand. The reports
+  flagged sections trending below expectations and enabled earlier outreach.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Helped achieve faster faculty interventions and optimized weekly support hours: by analyzing
+  performance data for 120+ upper-division students using Excel & R, identifying drivers like repeat errors on core topics and missed assignments that guided targeted tutoring.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Developed & maintained a KPI Dashboard using Tableau: for the economics courses supported,
+  tailored by class and professor. The dashboard tracked grade distributions, completion rates, and submission timelines, giving instructors a single view to spot at-risk students and adjust review and office hours.",
+  
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Increased on-time assignment completion by 12%: in an intermediate macroeconomics course by
+  flagging a deadline bottleneck using SQL and R. Analyzed gradebook and submission logs, tracked on-time vs. late by week, and recommended moving key deadlines off Friday nights to the instructor.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Logged 1,200 harness tests for QA: (D-SUB, RJ-45, USB), recording length variance and tolerance; recurring failures by SKU were surfaced 
+  early and fixed before final assembly.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Reviewed 30+ work orders with engineers to apply manufacturing tolerances: (length limits and continuity checks) while optimizing harness
+  lengths. Out-of-range cuts were flagged, and re-crimps were reduced on the line.",
+  
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Tracked progress systematically: to maintain accurate records and support production analysis while following detailed work orders to 
+  assemble harnesses and subassemblies."
+),
+  projects_override = tibble::tribble(
+  ~area, ~link, ~endMonth, ~year, ~detail_1, ~detail_2, ~detail_3,
+  "SAS Churn Rate Dashboard | Databel Retention Analytics", "https://eagereconomist-da.carrd.co/#project-two", "October", 2025,
+  "Used Tableau to flag 34.7% churn among customers: not on an unlimited plan who used less than 5 GB/month; advised marketing to explain the $4.34 in extra charges and migrate them to a better plan.",
+  "Identified 53% churn in customers: outside the internationally active group with twelve months or less in terms of account length. Recommended marketing offer one or two year contracts to stabilize retention.",
+  "Surfaced a high-value, small cohort of 177 customers: on an international plan with zero international calls (average $33.12 monthly charge). Used SQL to export the contact list and recommended outreach run a targeted campaign with a clear explanation of savings.",
+
+  "Light Vehicle Sales Forecasting & Market Analysis | Pinnacle Automotive Analytics Client Engagement", "https://eagereconomist-da.carrd.co/#project-one", "August", 2024,
+  "Developed a 18-month forecast and set a 1.27-1.30 million monthly baseline with ~6% YoY growth rate: through December 2025 using EViews and Excel for inventory planners and sales operations; recommended planning to this
+  baseline and recalibrating only after sustained variance.",
+  "Confirmed a post-1984 shift in seasonality, with sales increasing from November to December: and spring as the strongest merchandising window on average; recommended spring-focused campaigns with a winter KPI monitored against the pre-1984 baseline.",
+  "Found evidence of a link between growth in both real disposable income and YoY light vehicle sales: using EViews & Excel; when income jumped ~30% YoY in March 2021, sales spiked ~112% YoY in April 2021. Advised leadership and 
+  marketing to monitor income growth alongside sales each month to time promotions and inventory ramps",
+
+ "Racquet Segmentation & EDA | Topspin Supply Marketing Initiative", "https://eagereconomist-da.carrd.co/#project-three", "April", 2024,
+  "Verified 70% of models are mid-weight: using polars in Python to filter on specification tables. Recommended to pricing & merchandising to keep advanced lines premium with only small, targeted offers while reserving broader promotions for All-Court and Beginner racquets.",
+  "Priortized the 57% All-Court mix after profiling inventory: with SQL and building visualizations in Tableau. Recommended to merchandizing & E-commerce to feature All-Court first in placement and promotions to move the largest, most flexible stock.",
+  "Directed brand focus to Head: with double Wilson's stock using Power BI to analyze inventory. Advised merchandising to give Head primary promotion slots and homepage visibility before broad discounts."
+  ),
+  show_academic = FALSE,
+  show_github_header = FALSE,
+  max_bullets = 3
+)

--- a/data/shared.R
+++ b/data/shared.R
@@ -7,13 +7,13 @@ education <- tibble::tribble(
 
 professional_experience <- tibble::tribble(
   ~title, ~unit, ~startMonth, ~startYear, ~endMonth, ~endYear, ~where, ~detail,
-  "Special Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Improved an econometrics student's performance, as measured by a rise from 40% to 95% in 4 weeks, by delivering weekly 1:1 tutoring and custom practice sets",
-  "Special Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Worked closely with professors by integrating faculty input and analyzing ongoing results to refine and adapt tutoring methods, ensuring maximum impact and fostering long-term academic success",
-  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Collected and analyzed quiz/exam scores and assignment submissions using R (applying dplyr, tidyr, and ggplot2) to identify performance trends and optimize instructional approaches based on actionable, data-driven strategies",
-  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Tutored college upper-division students in multiple economics and business courses for CSUCI including microeconomics, macroeconomics, econometrics, and management information systems",
-  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Collaborated with faculty to share performance insights and refine tutoring approaches, ensuring alignment with course objectives and timely student support",
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Boosted an econometrics student's grade from 40% to 95% in 4 weeks by analyzing learning patterns and recommending targeted interventions",
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Analyzed SQL-based session data to optimize tutoring coverage, reallocating resources by 20% to the most requested economics courses",
+  "Data Analyst Consultant", "California State University Channel Islands", "January", 2023, "May", 2024, "Camarillo, California", "Worked closely with professors by integrating faculty input and analyzing ongoing results to refine and adapt tutoring methods, ensuring maximum impact and fostering long-term academic success",
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Analyzed performance data for 120+ upper-division students using SQL and Python, identifying trends to guide targeted tutoring",
+  "Embedded Peer Tutor", "California State University Channel Islands", "January", 2022, "December", 2022, "Camarillo, California", "Collected and analyzed quiz/exam scores and assignment submissions using R to identify performance trends and optimize instructional approaches based on actionable, data-driven strategies",
   "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Leveraged production data to verify harness integrity (D-SUB, RJ-45, USB), identify anomalies and ensure quality standards were met",
-  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Collaborated with engineers to examine design specifications and apply manufacturing tolerances—such as length limits and reliability thresholds—when optimizing harness lengths, guiding product modifications and ensuring overall production efficiency",
+  "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Collaborated with engineers to examine design specifications and apply manufacturing tolerances—such as length limits and reliability thresholds when optimizing harness lengths, guiding product modifications and ensuring overall production efficiency",
   "Production Assembler", "Rapid Manufacturing", "June", 2020, "October", 2020, "Anaheim, California", "Followed detailed work orders to assemble harnesses and subassemblies, systematically logging progress to maintain accurate records and support production analysis"
 )
 
@@ -27,17 +27,22 @@ skills <- tibble::tribble(
 
 projects <- tibble::tribble(
   ~area, ~link, ~endMonth, ~year, ~detail_1, ~detail_2, ~detail_3,
+  "Customer Churn Dashboard", "https://public.tableau.com/views/CustomerChurnDashboard_17606454613960/CustomerChurnDashboard?:language=en-US&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link", "October", 2025,
+  "Built an interactive Tableau dashboard that revealed key churn patterns across payment methods and regions, enabling stakeholders to address high-risk customer segments",
+  "Discovered that customers paying month-to-month via checks churned at a 57% rate with an average account length of 8 months, revealing payment method as a major churn factor",
+  "Found that customers in California exhibited the highest churn rate of 63% and longer tenures averaging 32 months, informing targeted retention and engagement strategies for high-risk regions",
+
   "A Multi-Equation Forecast Model of the U.S. Vehicle Sales Market", "https://www.dropbox.com/scl/fi/t7l3odfc0kgx2n189mzmz/c-7.pdf?rlkey=jr7q50qorns6eutgm1ydt1282&st=59ym65wm&dl=0", "August", 2024,
   "Managed a multi-frequency dataset by performing frequency conversion to wrangle all time-series variables to a monthly frequency",
   "Identified post-1984 seasonal reversal in U.S. light vehicle sales trends, as measured by historical increases from November to December in most years, by analyzing monthly sales patterns across a 48-year time series",
-  "Backed the theoretical expectation of VAR optimism by empirically showing its tendency to overshoot vehicle sales forecasts, with higher error magnitudes and volatility compared to ARIMA and structural approaches",
+  "Quantified forecast bias across VAR, ARIMA, and Structural models to validate theory-driven assumptions using in-sample and out-of-sample RMSE/MAPE metrics",
 
-  "kmflow", "https://github.com/eagereconomist/kmflow", "March", 2025,
-  "Developed a CLI toolset for unsupervised machine learning, used to cluster unlabeled data by applying K-Means and PCA, improving data segmentation workflows",
-  "Increased interpretability of cluster results by building an interactive Streamlit dashboard with silhouette scores, elbow method charts, and cluster profiling",
+  "K-Means Dashboard", "https://github.com/eagereconomist/kmflow", "March", 2025,
+  "Developed a CLI toolset for unsupervised machine learning, used to cluster unlabeled data by applying K-Means, improving data workflows",
+  "Increased interpretability of cluster results by building an interactive dashboard with silhouette scores, elbow method charts, and cluster profiling",
   NA,
 
-  "imputeflow", "https://github.com/eagereconomist/imputeflow", "August", 2025,
+  "Data Imputation CLI", "https://github.com/eagereconomist/imputeflow", "August", 2025,
   "Developed a modular CLI for missing data imputation in R, enabling users to clean tabular data with train/test masking support",
   "Reduced manual error handling in imputation workflows by supporting train/validate/test splitting with user-defined masks and progress indicators",
   NA

--- a/render_resume.R
+++ b/render_resume.R
@@ -7,6 +7,86 @@ ensure_packages <- function(pkgs) {
 }
 ensure_packages(c("rmarkdown", "pagedown"))
 
+# ---- Browser Detection ----
+is_exe <- function(p) {
+  nzchar(p) && file.exists(p) && isTRUE(file.access(p, 1) == 0)
+}
+
+detect_browser <- function() {
+  norm <- function(p) normalizePath(p, winslash = "/", mustWork = FALSE)
+
+  # 1) Explicit override
+  env <- Sys.getenv("CHROME_PATH", "")
+  if (is_exe(env)) return(norm(env))
+
+  # 2) pagedown's own finder
+  found <- tryCatch(pagedown::find_chrome(), error = function(e) "")
+  if (is_exe(found)) return(norm(found))
+
+  # 3) Common executable names on PATH
+  whiches <- unname(Sys.which(c(
+    "google-chrome-stable", "google-chrome", "chrome",
+    "chromium", "chromium-browser",
+    "brave", "brave-browser",
+    "microsoft-edge", "msedge"
+  )))
+  whiches <- whiches[nzchar(whiches)]
+  for (p in whiches) if (is_exe(p)) return(norm(p))
+
+  # 4) OS-specific well-known locations
+  sys <- Sys.info()[["sysname"]]
+  paths <- character(0)
+
+  if (identical(sys, "Darwin")) { # macOS .app bundles
+    paths <- c(
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+      "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+      "/Applications/Chromium.app/Contents/MacOS/Chromium",
+      file.path(Sys.getenv("HOME"), "Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+      file.path(Sys.getenv("HOME"), "Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"),
+      file.path(Sys.getenv("HOME"), "Applications/Brave Browser.app/Contents/MacOS/Brave Browser"),
+      file.path(Sys.getenv("HOME"), "Applications/Chromium.app/Contents/MacOS/Chromium")
+    )
+  } else if (.Platform$OS.type == "windows") {
+    prog    <- Sys.getenv("ProgramFiles", "C:/Program Files")
+    progx86 <- Sys.getenv("ProgramFiles(x86)", "C:/Program Files (x86)")
+    local   <- Sys.getenv("LOCALAPPDATA", "")
+    paths <- c(
+      file.path(prog,    "Google/Chrome/Application/chrome.exe"),
+      file.path(progx86, "Google/Chrome/Application/chrome.exe"),
+      file.path(local,   "Google/Chrome/Application/chrome.exe"),
+      file.path(prog,    "Microsoft/Edge/Application/msedge.exe"),
+      file.path(progx86, "Microsoft/Edge/Application/msedge.exe"),
+      file.path(local,   "Microsoft/Edge/Application/msedge.exe"),
+      file.path(prog,    "BraveSoftware/Brave-Browser/Application/brave.exe"),
+      file.path(progx86, "BraveSoftware/Brave-Browser/Application/brave.exe"),
+      file.path(local,   "BraveSoftware/Brave-Browser/Application/brave.exe"),
+      file.path(prog,    "Chromium/Application/chromium.exe"),
+      file.path(progx86, "Chromium/Application/chromium.exe")
+    )
+  } else { # Linux
+    paths <- c(
+      "/usr/bin/google-chrome-stable",
+      "/usr/bin/google-chrome",
+      "/usr/bin/chrome",
+      "/usr/bin/chromium",
+      "/usr/bin/chromium-browser",
+      "/snap/bin/chromium",
+      "/usr/bin/brave-browser",
+      "/usr/bin/microsoft-edge",
+      "/usr/bin/msedge"
+    )
+  }
+
+  for (p in paths) if (is_exe(p)) return(norm(p))
+
+  stop(
+    "No Chromium-based browser found. Install Chrome/Edge/Brave/Chromium, ",
+    "or set CHROME_PATH to the browser executable."
+  )
+}
+
 # ---- Render HTML Resume ----
 render_resume_html <- function(role) {
   dir.create("output", showWarnings = FALSE)
@@ -22,22 +102,23 @@ render_resume_html <- function(role) {
 
 # ---- Convert to PDF ----
 render_resume_pdf <- function(input_html, role) {
-  out_pdf <-  file.path("output", paste0("resume_", role, ".pdf"))
-  pagedown::chrome_print(input = input_html, output = out_pdf)
+  out_pdf <- file.path("output", paste0("resume_", role, ".pdf"))
+  browser_path <- detect_browser()
+  message("Using browser: ", browser_path)
+  pagedown::chrome_print(input = input_html, output = out_pdf, browser = browser_path)
   out_pdf
 }
 
 # ---- Main Build Function ----
 build_resume <- function(role = "data_scientist") {
   html_file <- render_resume_html(role)
-  pdf_file <- render_resume_pdf(html_file, role)
+  pdf_file  <- render_resume_pdf(html_file, role)
   message("Built ", pdf_file)
 }
 
 # ---- Parse CLI args & run ----
 args <- commandArgs(trailingOnly = TRUE)
 role <- "data_scientist"
-
 if (length(args)) {
   for (i in seq_along(args)) {
     if (args[i] %in% c("--role", "-r") && i < length(args)) {
@@ -45,5 +126,4 @@ if (length(args)) {
     }
   }
 }
-
 build_resume(role = role)

--- a/render_resume.R
+++ b/render_resume.R
@@ -31,7 +31,7 @@ build_resume <- function(role = "data_analyst") {
   dir.create("output", showWarnings = FALSE)
   html_file <- render_resume_html(role)
   pdf_file <- render_resume_pdf(html_file, role)
-  message("✓ Built ", pdf_file)
+  message("Built ", pdf_file)
 }
 
 # ---- Run ----

--- a/render_resume.R
+++ b/render_resume.R
@@ -2,13 +2,14 @@
 
 # ---- Setup Packages ----
 ensure_packages <- function(pkgs) {
-  to_install <- setdiff(pkgs, rownames(installed.packages()))
-  if (length(to_install)) install.packages(to_install)
+  to_install <- setdiff(pkgs, rownames(utils::installed.packages()))
+  if (length(to_install)) utils::install.packages(to_install)
 }
 ensure_packages(c("rmarkdown", "pagedown"))
 
 # ---- Render HTML Resume ----
 render_resume_html <- function(role) {
+  dir.create("output", showWarnings = FALSE)
   out_html <- file.path("output", paste0("resume_", role, ".html"))
   rmarkdown::render(
     "resume.Rmd",
@@ -21,18 +22,28 @@ render_resume_html <- function(role) {
 
 # ---- Convert to PDF ----
 render_resume_pdf <- function(input_html, role) {
-  out_pdf <- file.path("output", paste0("resume_", role, ".pdf"))
+  out_pdf <-  file.path("output", paste0("resume_", role, ".pdf"))
   pagedown::chrome_print(input = input_html, output = out_pdf)
   out_pdf
 }
 
 # ---- Main Build Function ----
-build_resume <- function(role = "data_analyst") {
-  dir.create("output", showWarnings = FALSE)
+build_resume <- function(role = "data_scientist") {
   html_file <- render_resume_html(role)
   pdf_file <- render_resume_pdf(html_file, role)
   message("Built ", pdf_file)
 }
 
-# ---- Run ----
-build_resume(role = "data_analyst")
+# ---- Parse CLI args & run ----
+args <- commandArgs(trailingOnly = TRUE)
+role <- "data_scientist"
+
+if (length(args)) {
+  for (i in seq_along(args)) {
+    if (args[i] %in% c("--role", "-r") && i < length(args)) {
+      role <- args[i + 1]
+    }
+  }
+}
+
+build_resume(role = role)

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -40,7 +40,7 @@ MAX_BULLETS   <- params$max_bullets %||% ROLE$max_bullets %||% 3
 
 # Highlight the leading fragment up to the first colon
 highlight_lead <- function(x) {
-  sub("^([^:]+:)", "<span class='lead'>\\1</span>", x, perl = TRUE)
+  sub("^\\s*([^:]+):\\s*", "<span class='lead'>\\1</span> ", x, perl = TRUE)
 }
 ```
 
@@ -115,7 +115,6 @@ for (group_key in sorted_keys) {
      </div>\n'
   ))
 
-  # If you want to honor MAX_BULLETS per role, truncate here
   n_bullets <- min(nrow(group), MAX_BULLETS)
   cat("<ul class='exp-bullets'>\n")
   for (i in seq_len(n_bullets)) {
@@ -174,6 +173,7 @@ if (exists("projects") && is.data.frame(projects)) {
     if (length(bullets) > 0) {
       cat("<ul class='proj-bullets'>\n")
       for (b in bullets) {
+        b <- highlight_lead(b)
         cat(glue::glue("<li>{b}</li>\n"))
       }
       cat("</ul>\n\n")

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -61,8 +61,9 @@ knitr::asis_output(out)
 ```
 
 ## Summary 
-```{r, results='asis'}
-cat(glue::glue("{rmarkdown::metadata$aboutme}\n\n"))
+```{r summary, echo=FALSE, results='asis'}
+SUMMARY_TEXT <- ROLE$summary %||% rmarkdown::metadata$aboutme
+knitr::asis_output(paste0(SUMMARY_TEXT, "\n\n"))
 ```
 
 ## Professional Experience  

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -171,7 +171,7 @@ if (is.data.frame(proj_entries) && nrow(proj_entries) > 0) {
     link  <- p$link
 
     title_html <- if (!is.na(link) && nzchar(link)) {
-      glue::glue('{title} <span class="proj-link">[<a href="{link}" target="_blank">click here to view project</a>]</span>')
+      glue::glue('{title} <span class="proj-link">(<a href="{link}" target="_blank">View Project</a>)</span>')
     } else {
       title
     }

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -45,16 +45,31 @@ highlight_lead <- function(x) {
 ```
 
 ```{r header, echo=FALSE, results='asis'}
-# Build a Markdown contact line with conditional GitHub link
+# Defaults (used if a role doesn't specify overrides)
+DEFAULT_PORTFOLIO_URL   <- "https://eagereconomist-da.carrd.co/"
+DEFAULT_PORTFOLIO_LABEL <- "Portfolio"
+
+# Pull role-specific values (or fallback)
+PORTFOLIO_URL   <- ROLE$portfolio_url    %||% DEFAULT_PORTFOLIO_URL
+PORTFOLIO_LABEL <- ROLE$portfolio_label  %||% DEFAULT_PORTFOLIO_LABEL
+SHOW_PORTFOLIO  <- if (is.null(ROLE$show_portfolio_header)) TRUE else isTRUE(ROLE$show_portfolio_header)
+
+portfolio_part <- if (SHOW_PORTFOLIO && nzchar(PORTFOLIO_URL)) {
+  paste0(" | [", PORTFOLIO_LABEL, "](", PORTFOLIO_URL, ")")
+} else {
+  ""
+}
+
+github_link <- if (isTRUE(ROLE$show_github_header)) " | [GitHub](https://github.com/eagereconomist)" else ""
+
 CONTACT_LINE <- paste0(
   "emmiller.msqe@gmail.com | ",
-  "[+1 (714) 812-0003](tel:+17148120003) | ",
-  "[Portfolio](https://eagereconomist-da.carrd.co/)",
-  if (isTRUE(ROLE$show_github_header)) " | [GitHub](https://github.com/eagereconomist)" else "",
+  "[+1 (714) 812-0003](tel:+17148120003)",
+  portfolio_part,
+  github_link,
   " | [LinkedIn](https://www.linkedin.com/in/eric-miller-20a162224/)"
 )
 
-# Emit a Pandoc fenced div so CSS classes apply cleanly
 out <- paste0(
   "::: {.centered-header}\n",
   "# Eric Miller\n",

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -1,7 +1,7 @@
 ---
 name: "Eric Miller"
-aboutme: "Data-focused analyst with training in econometrics and applied experience using statistical modeling, machine learning, and data wrangling techniques to uncover actionable insights. 
-          Proficient in R, Python, and SQL, with a strong foundation in time-series analysis."
+aboutme: "Data analyst who favors clarity over noise, leaning on clean visuals and language tailored to the audience it serves.
+        I build dashboards and practical forecasts shaped by real questions from the people who use them."
 output:
   pagedown::html_paged:
     css: compact.css

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -1,8 +1,7 @@
 --- 
 name: "Eric Miller"
-aboutme: "Detail-oriented data analyst with a strong background in economics and quantitative analysis.
-         Proficient in Python, R, SQL, EViews, and JMP Pro, with proven expertise in time-series econometrics and forecasting methods. 
-         Adept at identifying strategic opportunities to enhance company margins and maximize profitability through comprehensive, data-driven analysis."
+aboutme: "Data-focused analyst with training in econometrics and applied experience using statistical modeling, machine learning, and data wrangling techniques to uncover actionable insights. 
+          Proficient in R, Python, and SQL, with a strong foundation in time-series analysis."
 output:
   pagedown::html_paged:
     css: compact.css
@@ -21,23 +20,35 @@ params:
 <div class="centered-header">
   <h1>Eric Miller</h1>
   <p class="contact-info">
-    <a href="mailto:ericmiller@callutheran.edu">email</a>&nbsp;|&nbsp;
+    emmiller.msqe@gmail.com&nbsp;|&nbsp;
     <a href="tel:+17148120003">+1 (714) 812-0003</a>&nbsp;|&nbsp;
-    <a href="https://eagereconomist.carrd.co/">Portfolio</a>&nbsp;|&nbsp;
+    <a href="https://eagereconomist-da.carrd.co/">Portfolio</a>&nbsp;|&nbsp;
     <a href="https://github.com/eagereconomist">GitHub</a>&nbsp;|&nbsp;
     <a href="https://www.linkedin.com/in/eric-miller-20a162224/">LinkedIn</a>
   </p>
 </div>
 
+
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE)
 `%||%` <- function(x, y) if (!is.null(x)) x else y
+
+# Base data (shared tables)
 source("data/shared.R", local = TRUE)
-role_file <- file.path("data", "roles", paste0(params$role, ".R"))
+
+# Load role file dynamically into its own environment
+role_dir <- file.path("data", "roles")
+role_file <- file.path(role_dir, paste0(params$role, ".R"))
 if (!file.exists(role_file)) stop("Missing role file: ", role_file)
-source(role_file, local = TRUE)
-SHOW_ACADEMIC <- isTRUE(params$show_academic)
-MAX_BULLETS <- params$max_bullets %||% 3
+
+role_env <- new.env()
+sys.source(role_file, envir = role_env)
+ROLE <- role_env$role
+if (is.null(ROLE) || !is.list(ROLE)) stop("Role file must define `role <- list(...)`")
+
+# Effective switches
+SHOW_ACADEMIC <- isTRUE(params$show_academic %||% ROLE$show_academic)
+MAX_BULLETS <- params$max_bullets %||% ROLE$max_bullets %||% 3
 ```
 
 ```{r, results='asis'}
@@ -53,7 +64,7 @@ cat(glue::glue("{rmarkdown::metadata$aboutme}\n\n"))
 
 ## Professional Experience  
 ```{r, results='asis'}
-entries <- if (!is.null(role_data$experience_override)) role_data$experience_override else professional_experience
+entries <- if (!is.null(ROLE$experience_override)) ROLE$experience_override else professional_experience
 
 # Create group key for each job
 entries$group_id <- paste(entries$title, entries$unit, entries$where, entries$startMonth, entries$startYear, entries$endMonth, entries$endYear)
@@ -71,8 +82,8 @@ group_meta <- lapply(by_job, function(g) {
 }) |> dplyr::bind_rows()
 
 # Sort group keys by most recent end date
-sorted_keys <- group_meta |> 
-  dplyr::arrange(dplyr::desc(endYear), dplyr::desc(endMonthNum)) |> 
+sorted_keys <- group_meta |>
+  dplyr::arrange(dplyr::desc(endYear), dplyr::desc(endMonthNum)) |>
   dplyr::pull(group_id)
 
 # Now render in sorted order
@@ -94,8 +105,10 @@ for (group_key in sorted_keys) {
      </div>\n'
   ))
 
+  # If you want to honor MAX_BULLETS per role, truncate here
+  n_bullets <- min(nrow(group), MAX_BULLETS)
   cat("<ul class='exp-bullets'>\n")
-  for (i in seq_len(nrow(group))) {
+  for (i in seq_len(n_bullets)) {
     detail <- group$detail[i]
     cat(glue::glue("<li>{detail}</li>\n"))
   }
@@ -105,7 +118,7 @@ for (group_key in sorted_keys) {
 
 ## Skills
 ```{r, results='asis'}
-skills_tbl <- if (!is.null(role_data$skills_tbl)) role_data$skills_tbl else skills
+skills_tbl <- if (!is.null(ROLE$skills_tbl)) ROLE$skills_tbl else skills
 for (i in seq_len(nrow(skills_tbl))) {
   s <- skills_tbl[i, ]
   glue::glue("**{s$area}:** {s$skills}\n") |> cat("\n")
@@ -204,14 +217,8 @@ if (exists("certifications") && is.data.frame(certifications)) {
          <div class="cert-date">{date}</div>
        </div>\n'
     ))
-
-    if (!is.na(id) && nzchar(id)) {
-      cat(glue::glue("<ul class='cert-bullets'><li>{id}</li></ul>\n"))
     }
-
-    cat("<div class='cert-spacer'></div>\n")
   }
-}
 ```
 
 ## Education

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -60,13 +60,13 @@ out <- paste0(
 knitr::asis_output(out)
 ```
 
-## Summary 
+## SUMMARY
 ```{r summary, echo=FALSE, results='asis'}
 SUMMARY_TEXT <- ROLE$summary %||% rmarkdown::metadata$aboutme
 knitr::asis_output(paste0(SUMMARY_TEXT, "\n\n"))
 ```
 
-## Professional Experience  
+## PROFESSIONAL EXPERIENCE
 ```{r, results='asis'}
 entries <- if (!is.null(ROLE$experience_override)) ROLE$experience_override else professional_experience
 
@@ -120,7 +120,8 @@ for (group_key in sorted_keys) {
 }
 ```
 
-## Skills
+## SKILLS
+::: { .skills }
 ```{r, results='asis'}
 skills_tbl <- if (!is.null(ROLE$skills_tbl)) ROLE$skills_tbl else skills
 for (i in seq_len(nrow(skills_tbl))) {
@@ -129,7 +130,7 @@ for (i in seq_len(nrow(skills_tbl))) {
 }
 ```
 
-## Projects  
+## PROJECTS  
 ```{r, results='asis'}
 if (exists("projects") && is.data.frame(projects)) {
   projects$group_id <- paste(projects$area, projects$endMonth, projects$year)
@@ -185,7 +186,7 @@ if (exists("projects") && is.data.frame(projects)) {
 }
 ```
 
-## Certifications
+## CERTIFICATIONS
 ```{r, results='asis'}
 if (exists("certifications") && is.data.frame(certifications)) {
   certifications$group_id <- paste(certifications$area, certifications$endMonth, certifications$year)
@@ -225,7 +226,7 @@ if (exists("certifications") && is.data.frame(certifications)) {
   }
 ```
 
-## Education
+## EDUCATION
 ```{r, results='asis'}
 if (exists("education") && is.data.frame(education)) {
   for (i in seq_len(nrow(education))) {

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -127,15 +127,18 @@ for (group_key in sorted_keys) {
 
 ## DATA ANALYST PROJECTS  
 ```{r, results='asis'}
-if (exists("projects") && is.data.frame(projects)) {
-  projects$group_id <- paste(projects$area, projects$endMonth, projects$year)
+# Use role-specific projects if provided; otherwise fall back to shared projects
+proj_entries <- if (!is.null(ROLE$projects_override)) ROLE$projects_override else projects
 
-  by_proj <- split(projects, projects$group_id)
+if (is.data.frame(proj_entries) && nrow(proj_entries) > 0) {
+  proj_entries$group_id <- paste(proj_entries$area, proj_entries$endMonth, proj_entries$year)
+
+  by_proj <- split(proj_entries, proj_entries$group_id)
 
   proj_meta <- lapply(by_proj, function(g) {
     tibble::tibble(
-      group_id = g$group_id[1],
-      year = g$year[1],
+      group_id    = g$group_id[1],
+      year        = g$year[1],
       endMonthNum = match(g$endMonth[1], month.name)
     )
   }) |> dplyr::bind_rows()
@@ -149,10 +152,9 @@ if (exists("projects") && is.data.frame(projects)) {
     p <- group[1, ]
 
     title <- p$area
-    when <- glue::glue("{p$endMonth} {p$year}")
-    link <- p$link
+    when  <- glue::glue("{p$endMonth} {p$year}")
+    link  <- p$link
 
-    # Format: Project Title [link]   (on left), Date on right
     title_html <- if (!is.na(link) && nzchar(link)) {
       glue::glue('{title} <span class="proj-link">[<a href="{link}" target="_blank">click here to view project</a>]</span>')
     } else {
@@ -166,7 +168,6 @@ if (exists("projects") && is.data.frame(projects)) {
        </div>\n'
     ))
 
-    # Bullets (up to 3)
     bullets <- unlist(group[1, c("detail_1", "detail_2", "detail_3")])
     bullets <- bullets[!is.na(bullets) & nzchar(bullets)]
 

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -120,17 +120,7 @@ for (group_key in sorted_keys) {
 }
 ```
 
-## SKILLS
-::: { .skills }
-```{r, results='asis'}
-skills_tbl <- if (!is.null(ROLE$skills_tbl)) ROLE$skills_tbl else skills
-for (i in seq_len(nrow(skills_tbl))) {
-  s <- skills_tbl[i, ]
-  glue::glue("**{s$area}:** {s$skills}\n") |> cat("\n")
-}
-```
-
-## PROJECTS  
+## DATA ANALYST PROJECTS  
 ```{r, results='asis'}
 if (exists("projects") && is.data.frame(projects)) {
   projects$group_id <- paste(projects$area, projects$endMonth, projects$year)
@@ -183,6 +173,16 @@ if (exists("projects") && is.data.frame(projects)) {
       cat("</ul>\n\n")
     }
   }
+}
+```
+
+## SKILLS
+::: { .skills }
+```{r, results='asis'}
+skills_tbl <- if (!is.null(ROLE$skills_tbl)) ROLE$skills_tbl else skills
+for (i in seq_len(nrow(skills_tbl))) {
+  s <- skills_tbl[i, ]
+  glue::glue("**{s$area}:** {s$skills}\n") |> cat("\n")
 }
 ```
 

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -260,8 +260,6 @@ if (exists("education") && is.data.frame(education)) {
     if (!is.na(detail) && nzchar(detail)) {
       cat(glue::glue("<ul class='edu-bullets'><li>{detail}</li></ul>\n"))
     }
-
-    cat("<br>\n")  # spacing between entries
   }
 }
 ```

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -1,4 +1,4 @@
---- 
+---
 name: "Eric Miller"
 aboutme: "Data-focused analyst with training in econometrics and applied experience using statistical modeling, machine learning, and data wrangling techniques to uncover actionable insights. 
           Proficient in R, Python, and SQL, with a strong foundation in time-series analysis."
@@ -17,18 +17,6 @@ params:
   max_bullets: 3
 ---
 
-<div class="centered-header">
-  <h1>Eric Miller</h1>
-  <p class="contact-info">
-    emmiller.msqe@gmail.com&nbsp;|&nbsp;
-    <a href="tel:+17148120003">+1 (714) 812-0003</a>&nbsp;|&nbsp;
-    <a href="https://eagereconomist-da.carrd.co/">Portfolio</a>&nbsp;|&nbsp;
-    <a href="https://github.com/eagereconomist">GitHub</a>&nbsp;|&nbsp;
-    <a href="https://www.linkedin.com/in/eric-miller-20a162224/">LinkedIn</a>
-  </p>
-</div>
-
-
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE)
 `%||%` <- function(x, y) if (!is.null(x)) x else y
@@ -37,7 +25,7 @@ knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE)
 source("data/shared.R", local = TRUE)
 
 # Load role file dynamically into its own environment
-role_dir <- file.path("data", "roles")
+role_dir  <- file.path("data", "roles")
 role_file <- file.path(role_dir, paste0(params$role, ".R"))
 if (!file.exists(role_file)) stop("Missing role file: ", role_file)
 
@@ -48,13 +36,28 @@ if (is.null(ROLE) || !is.list(ROLE)) stop("Role file must define `role <- list(.
 
 # Effective switches
 SHOW_ACADEMIC <- isTRUE(params$show_academic %||% ROLE$show_academic)
-MAX_BULLETS <- params$max_bullets %||% ROLE$max_bullets %||% 3
+MAX_BULLETS   <- params$max_bullets %||% ROLE$max_bullets %||% 3
 ```
 
-```{r, results='asis'}
-cat(glue::glue("**{rmarkdown::metadata$name} {rmarkdown::metadata$surname}**  
-{rmarkdown::metadata$phone} | {rmarkdown::metadata$email} | {rmarkdown::metadata$linkedin} | {rmarkdown::metadata$portfolio} | {rmarkdown::metadata$github})  
-"))
+```{r header, echo=FALSE, results='asis'}
+# Build a Markdown contact line with conditional GitHub link
+CONTACT_LINE <- paste0(
+  "emmiller.msqe@gmail.com | ",
+  "[+1 (714) 812-0003](tel:+17148120003) | ",
+  "[Portfolio](https://eagereconomist-da.carrd.co/)",
+  if (isTRUE(ROLE$show_github_header)) " | [GitHub](https://github.com/eagereconomist)" else "",
+  " | [LinkedIn](https://www.linkedin.com/in/eric-miller-20a162224/)"
+)
+
+# Emit a Pandoc fenced div so CSS classes apply cleanly
+out <- paste0(
+  "::: {.centered-header}\n",
+  "# Eric Miller\n",
+  "<p class=\"contact-info\">", CONTACT_LINE, "</p>\n",
+  ":::"
+)
+
+knitr::asis_output(out)
 ```
 
 ## Summary 

--- a/resume.Rmd
+++ b/resume.Rmd
@@ -37,6 +37,11 @@ if (is.null(ROLE) || !is.list(ROLE)) stop("Role file must define `role <- list(.
 # Effective switches
 SHOW_ACADEMIC <- isTRUE(params$show_academic %||% ROLE$show_academic)
 MAX_BULLETS   <- params$max_bullets %||% ROLE$max_bullets %||% 3
+
+# Highlight the leading fragment up to the first colon
+highlight_lead <- function(x) {
+  sub("^([^:]+:)", "<span class='lead'>\\1</span>", x, perl = TRUE)
+}
 ```
 
 ```{r header, echo=FALSE, results='asis'}
@@ -68,6 +73,7 @@ knitr::asis_output(paste0(SUMMARY_TEXT, "\n\n"))
 
 ## PROFESSIONAL EXPERIENCE
 ```{r, results='asis'}
+
 entries <- if (!is.null(ROLE$experience_override)) ROLE$experience_override else professional_experience
 
 # Create group key for each job
@@ -113,7 +119,7 @@ for (group_key in sorted_keys) {
   n_bullets <- min(nrow(group), MAX_BULLETS)
   cat("<ul class='exp-bullets'>\n")
   for (i in seq_len(n_bullets)) {
-    detail <- group$detail[i]
+    detail <- highlight_lead(group$detail[i])
     cat(glue::glue("<li>{detail}</li>\n"))
   }
   cat("</ul>\n\n")
@@ -185,6 +191,7 @@ for (i in seq_len(nrow(skills_tbl))) {
   glue::glue("**{s$area}:** {s$skills}\n") |> cat("\n")
 }
 ```
+:::
 
 ## CERTIFICATIONS
 ```{r, results='asis'}


### PR DESCRIPTION
# Description

Version 0.0.1| Role profiles, header/skills layout fixes, build improvements

## Summary
This PR introduces role-driven resume rendering and expands role profiles, enabling role-specific summaries, project overrides, and optional header elements (GitHub + portfolio). It also includes CSS/layout refinements to improve PDF output consistency and a build improvement to auto-detect a Chromium browser for printing.

## Key changes
### Role system + rendering pipeline
- Standardized role files to export a generic role list.
- Added `--role` flag to the render/build script and load `ROLE` from params for consistent usage throughout rendering.
- Added role-specific summary text with fallback to `aboutme` YAML when missing.
- Added per-role options:
  - `show_github_header` toggle
  - portfolio link support (`portfolio_url`, `portfolio_label`, `show_portfolio_*`)
  - `projects_override` support in Projects section (with fallback behavior)

### New role profiles
- Added role profiles:
  - data_scientist
  - business_analyst
  - forecasting_analyst
  - junior_data_scientist
  - research_analyst
  - user_acquisition_analyst
  - CRM_Analyst
- Updated/iterated data analyst role details (summary, skills, and role content).

### Resume layout + styling improvements
- Fixed header rendering via Pandoc fenced div and dynamic contact content.
- Wrapped Skills section in a scoped `.skills` container and updated label styling (unbold + color match).
- Adjusted Skills spacing and fixed fenced div closure to prevent layout issues.
- Moved Skills section below Data Analyst Projects section (where applicable).
- Improved bullet text presentation:
  - darker grey “insight” tone
  - justified bullets + hyphenation for better PDF flow
- Projects section polish:
  - mirrored “lead” styling from Experience
  - standardized “View Project” link styling (blue by default)
- Education formatting:
  - removed manual `<br>` to prevent overflow
  - added consistent spacing between Education entries

### Build/print improvement
- Auto-detect Chrome/Edge/Brave/Chromium for `chrome_print` to reduce local setup friction.